### PR TITLE
feat: add pause state during game session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "bevy_shader",
  "bevy_time",
  "bevy_transform",
+ "bevy_ui_render",
  "bevy_utils",
  "bevy_window",
  "bevy_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bevy_egui = { version = "0.39.1", optional = true, default-features = false, fea
     "open_url",
     "default_fonts",
     "render",
+    "bevy_ui",
 ] }
 bevy_embedded_assets = "0.15.0"
 bevy_kira_audio = "0.25.0"

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -12,6 +12,7 @@ use self::{
     ui::{UiPlugin, button::GameButtonPlugin},
 };
 
+pub mod phase;
 pub mod score;
 pub mod session;
 pub mod settings;
@@ -22,8 +23,12 @@ pub struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((SessionPlugin, TilePlugin, UiPlugin, GameButtonPlugin))
-            .add_systems(OnEnter(AppState::Game), setup_game);
+        app.add_sub_state::<phase::GamePhase>()
+            .add_plugins((SessionPlugin, TilePlugin, UiPlugin, GameButtonPlugin))
+            .add_systems(OnEnter(AppState::Game), setup_game)
+            .add_systems(Update, toggle_pause.run_if(in_state(AppState::Game)))
+            .add_systems(OnEnter(phase::GamePhase::Paused), spawn_pause_overlay)
+            .add_systems(OnEnter(phase::GamePhase::Playing), despawn_pause_overlay);
     }
 }
 
@@ -119,4 +124,55 @@ fn setup_game(mut commands: Commands, settings: Res<GameSettings>) {
         Answer::default(),
         marker,
     ));
+}
+
+/// Toggle between Playing and Paused on Escape.
+fn toggle_pause(
+    input: Res<ButtonInput<KeyCode>>,
+    current: Res<State<phase::GamePhase>>,
+    mut next: ResMut<NextState<phase::GamePhase>>,
+) {
+    if input.just_pressed(KeyCode::Escape) {
+        next.set(match current.get() {
+            phase::GamePhase::Playing => phase::GamePhase::Paused,
+            phase::GamePhase::Paused => phase::GamePhase::Playing,
+        });
+    }
+}
+
+#[derive(Component)]
+struct PauseOverlay;
+
+fn spawn_pause_overlay(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let font = asset_server.load("embedded://fonts/FiraSans-Bold.ttf");
+
+    commands.spawn((
+        PauseOverlay,
+        Node {
+            width: percent(100),
+            height: percent(100),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            position_type: PositionType::Absolute,
+            ..default()
+        },
+        BackgroundColor(Color::srgba(0.0, 0.0, 0.0, 0.6)),
+        // Render on top of the game UI
+        GlobalZIndex(10),
+        children![(
+            Text::new("PAUSED"),
+            TextFont {
+                font,
+                font_size: 80.0,
+                ..default()
+            },
+            TextColor(Color::WHITE),
+        )],
+    ));
+}
+
+fn despawn_pause_overlay(mut commands: Commands, query: Query<Entity, With<PauseOverlay>>) {
+    for entity in &query {
+        commands.entity(entity).despawn();
+    }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -148,6 +148,7 @@ fn spawn_pause_overlay(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn((
         PauseOverlay,
+        DespawnOnExit(AppState::Game),
         Node {
             width: percent(100),
             height: percent(100),

--- a/src/game/phase.rs
+++ b/src/game/phase.rs
@@ -1,0 +1,13 @@
+use bevy::prelude::*;
+
+use crate::state::AppState;
+
+/// Sub-state of [`AppState::Game`] that controls whether the session is
+/// actively running or paused.
+#[derive(Clone, Copy, Default, Eq, PartialEq, Debug, Hash, SubStates)]
+#[source(AppState = AppState::Game)]
+pub enum GamePhase {
+    #[default]
+    Playing,
+    Paused,
+}

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -35,7 +35,7 @@ impl Plugin for SessionPlugin {
                 Update,
                 (timer_system, end_of_round_system)
                     .chain()
-                    .run_if(in_state(AppState::Game).and(in_state(GamePhase::Playing))),
+                    .run_if(in_state(GamePhase::Playing)),
             );
     }
 }

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 
 use crate::{
     game::{
+        phase::GamePhase,
         score::{ScoreHistory, ScoreRecord},
         settings::GameSettings,
         tile::{color::TileColor, position::TilePosition, sound::TileSound},
@@ -34,7 +35,7 @@ impl Plugin for SessionPlugin {
                 Update,
                 (timer_system, end_of_round_system)
                     .chain()
-                    .run_if(in_state(AppState::Game)),
+                    .run_if(in_state(GamePhase::Playing)),
             );
     }
 }

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -35,7 +35,7 @@ impl Plugin for SessionPlugin {
                 Update,
                 (timer_system, end_of_round_system)
                     .chain()
-                    .run_if(in_state(GamePhase::Playing)),
+                    .run_if(in_state(AppState::Game).and(in_state(GamePhase::Playing))),
             );
     }
 }

--- a/src/game/ui/button.rs
+++ b/src/game/ui/button.rs
@@ -6,6 +6,7 @@ use crate::{
         session::{Session, answer::Answer},
     },
     palette,
+    state::AppState,
 };
 
 pub const NORMAL_BUTTON: Color = palette::SLATE_800;
@@ -63,7 +64,8 @@ impl Plugin for GameButtonPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            (button_system, button_shortcut_system).run_if(in_state(GamePhase::Playing)),
+            (button_system, button_shortcut_system)
+                .run_if(in_state(AppState::Game).and(in_state(GamePhase::Playing))),
         );
     }
 }

--- a/src/game/ui/button.rs
+++ b/src/game/ui/button.rs
@@ -1,9 +1,11 @@
 use bevy::prelude::*;
 
 use crate::{
-    game::session::{Session, answer::Answer},
+    game::{
+        phase::GamePhase,
+        session::{Session, answer::Answer},
+    },
     palette,
-    state::AppState,
 };
 
 pub const NORMAL_BUTTON: Color = palette::SLATE_800;
@@ -61,7 +63,7 @@ impl Plugin for GameButtonPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            (button_system, button_shortcut_system).run_if(in_state(AppState::Game)),
+            (button_system, button_shortcut_system).run_if(in_state(GamePhase::Playing)),
         );
     }
 }

--- a/src/game/ui/button.rs
+++ b/src/game/ui/button.rs
@@ -6,7 +6,6 @@ use crate::{
         session::{Session, answer::Answer},
     },
     palette,
-    state::AppState,
 };
 
 pub const NORMAL_BUTTON: Color = palette::SLATE_800;
@@ -64,8 +63,7 @@ impl Plugin for GameButtonPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            (button_system, button_shortcut_system)
-                .run_if(in_state(AppState::Game).and(in_state(GamePhase::Playing))),
+            (button_system, button_shortcut_system).run_if(in_state(GamePhase::Playing)),
         );
     }
 }


### PR DESCRIPTION
## Summary

Press **Escape** to pause/unpause the game during a session.

### Implementation

- **`GamePhase` sub-state** — a `SubStates` enum (`Playing` / `Paused`) derived from `AppState::Game`. Automatically enters `Playing` when the game starts and is removed when leaving `AppState::Game`.

- **Systems gated on `GamePhase::Playing`** — timer, round progression, and button input systems only run while playing. The game freezes completely while paused.

- **Pause overlay** — a full-screen semi-transparent black overlay (`60%` opacity) with centered "PAUSED" text (80px). Spawns on `OnEnter(GamePhase::Paused)`, despawns on `OnEnter(GamePhase::Playing)`.

- **Escape toggles** — works in both directions. A single `toggle_pause` system runs in `Update` gated on `AppState::Game` (not `GamePhase`) so it works regardless of pause state.

### Files changed

| File | Change |
|------|--------|
| `game/phase.rs` | New — `GamePhase` sub-state definition |
| `game/mod.rs` | Register sub-state, pause toggle, overlay spawn/despawn |
| `game/session/mod.rs` | Gate timer + round systems on `GamePhase::Playing` |
| `game/ui/button.rs` | Gate button systems on `GamePhase::Playing` |