### PR TITLE
feat: persist settings and scores in SQLite database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,6 +2462,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,6 +2752,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,6 +2987,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -3242,6 +3286,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3728,6 +3781,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3943,8 +4007,10 @@ dependencies = [
  "bevy_egui",
  "bevy_embedded_assets",
  "bevy_kira_audio",
+ "dirs",
  "image",
  "rand 0.10.0",
+ "rusqlite",
 ]
 
 [[package]]
@@ -4456,6 +4522,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
@@ -4978,6 +5050,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5053,6 +5136,20 @@ name = "rtrb"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
+
+[[package]]
+name = "rusqlite"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -5917,6 +6014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5937,6 +6040,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ bevy_egui = { version = "0.39.1", optional = true, default-features = false, fea
 ] }
 bevy_embedded_assets = "0.15.0"
 bevy_kira_audio = "0.25.0"
+dirs = "6.0"
 image = "0.25.10"
 rand = "0.10.0"
+rusqlite = { version = "0.35", features = ["bundled"] }
 
 [workspace]
 resolver = "2"

--- a/src/game/score.rs
+++ b/src/game/score.rs
@@ -9,6 +9,8 @@ pub struct ScoreRecord {
     pub correct: usize,
     pub wrong: usize,
     pub f1_score_percent: usize,
+    /// ISO-8601 timestamp (filled by the database on insert).
+    pub played_at: String,
 }
 
 /// Accumulated score history across game sessions.

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         settings::GameSettings,
         tile::{color::TileColor, position::TilePosition, shape::TileShape, sound::TileSound},
     },
+    persistence::Database,
     state::AppState,
 };
 
@@ -110,8 +111,9 @@ fn end_of_round_system(
     round.current += 1;
 }
 
-/// When the last round is reached, record the score and return to menu.
+/// When the last round is reached, persist the score and return to menu.
 fn end_of_game_system(
+    db: Res<Database>,
     mut settings: ResMut<GameSettings>,
     mut history: ResMut<ScoreHistory>,
     mut app_state: ResMut<NextState<AppState>>,
@@ -123,14 +125,20 @@ fn end_of_game_system(
         return;
     }
 
-    history.0.push(ScoreRecord {
+    let record = ScoreRecord {
         n: engine.n(),
         total_rounds: round.total,
         round_duration: timer.0.duration().as_secs_f32(),
         correct: score.correct(),
         wrong: score.wrong(),
         f1_score_percent: score.f1_score_percent(),
-    });
+        ..default()
+    };
+
+    db.insert_score(&record);
+
+    // Reload the full history so timestamps are populated.
+    *history = db.load_scores();
 
     if score.f1_score_percent() >= 80 {
         settings.n += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod debug;
 pub mod game;
 pub mod menu;
 pub mod palette;
+pub mod persistence;
 pub mod splash;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,21 @@ use nback::debug::DebugPlugin;
 use nback::{
     asset::AudioAssets,
     config,
-    game::{GamePlugin, score::ScoreHistory, settings::GameSettings},
+    game::GamePlugin,
     menu::MenuPlugin,
     palette,
+    persistence::{Database, PersistencePlugin},
     splash::SplashPlugin,
     state::AppState,
 };
 
 fn main() {
     let mut app = App::new();
+
+    // Open (or create) the database and load persisted state.
+    let db = Database::open();
+    let settings = db.load_settings();
+    let scores = db.load_scores();
 
     app.add_plugins(EmbeddedAssetPlugin::default())
         .add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -35,9 +41,16 @@ fn main() {
                 .continue_to_state(AppState::Menu)
                 .load_collection::<AudioAssets>(),
         )
-        .insert_resource(GameSettings::default())
-        .insert_resource(ScoreHistory::default())
-        .add_plugins((AudioPlugin, SplashPlugin, MenuPlugin, GamePlugin));
+        .insert_resource(settings)
+        .insert_resource(scores)
+        .insert_resource(db)
+        .add_plugins((
+            AudioPlugin,
+            PersistencePlugin,
+            SplashPlugin,
+            MenuPlugin,
+            GamePlugin,
+        ));
 
     #[cfg(feature = "debug")]
     app.add_plugins(DebugPlugin);

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,177 @@
+use std::{path::PathBuf, sync::Mutex};
+
+use bevy::prelude::*;
+use rusqlite::Connection;
+
+use crate::game::{
+    score::{ScoreHistory, ScoreRecord},
+    settings::GameSettings,
+};
+
+/// Wraps a SQLite connection as a Bevy resource.
+///
+/// `Connection` is not `Sync`, so we wrap it in a `Mutex`.
+#[derive(Resource)]
+pub struct Database {
+    conn: Mutex<Connection>,
+}
+
+impl Database {
+    /// Open (or create) the database in the platform data directory.
+    ///
+    /// Falls back to the current directory if no data directory is available.
+    pub fn open() -> Self {
+        let path = db_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        info!("opening database at {}", path.display());
+        let conn = Connection::open(&path).expect("failed to open database");
+        let db = Database {
+            conn: Mutex::new(conn),
+        };
+        db.migrate();
+        db
+    }
+
+    // -- migrations --------------------------------------------------------
+
+    fn migrate(&self) {
+        let conn = self.conn.lock().expect("db lock poisoned");
+        conn.execute_batch(
+            "
+                CREATE TABLE IF NOT EXISTS settings (
+                    id          INTEGER PRIMARY KEY CHECK (id = 1),
+                    n           INTEGER NOT NULL DEFAULT 2,
+                    rounds      INTEGER NOT NULL DEFAULT 24,
+                    round_time  REAL    NOT NULL DEFAULT 3.0,
+                    position    INTEGER NOT NULL DEFAULT 1,
+                    color       INTEGER NOT NULL DEFAULT 1,
+                    shape       INTEGER NOT NULL DEFAULT 1,
+                    sound       INTEGER NOT NULL DEFAULT 1
+                );
+
+                INSERT OR IGNORE INTO settings (id) VALUES (1);
+
+                CREATE TABLE IF NOT EXISTS scores (
+                    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                    played_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+                    n                INTEGER NOT NULL,
+                    total_rounds     INTEGER NOT NULL,
+                    round_duration   REAL    NOT NULL,
+                    correct          INTEGER NOT NULL,
+                    wrong            INTEGER NOT NULL,
+                    f1_score_percent INTEGER NOT NULL
+                );
+                ",
+        )
+        .expect("failed to run migrations");
+    }
+
+    // -- settings ----------------------------------------------------------
+
+    pub fn load_settings(&self) -> GameSettings {
+        let conn = self.conn.lock().expect("db lock poisoned");
+        conn.query_row("SELECT * FROM settings WHERE id = 1", [], |row| {
+            Ok(GameSettings {
+                n: row.get::<_, usize>("n")?,
+                rounds: row.get::<_, usize>("rounds")?,
+                round_time: row.get::<_, f32>("round_time")?,
+                position: row.get::<_, bool>("position")?,
+                color: row.get::<_, bool>("color")?,
+                shape: row.get::<_, bool>("shape")?,
+                sound: row.get::<_, bool>("sound")?,
+            })
+        })
+        .unwrap_or_default()
+    }
+
+    pub fn save_settings(&self, s: &GameSettings) {
+        let conn = self.conn.lock().expect("db lock poisoned");
+        conn.execute(
+            "UPDATE settings SET n=?1, rounds=?2, round_time=?3,
+                 position=?4, color=?5, shape=?6, sound=?7
+                 WHERE id = 1",
+            rusqlite::params![
+                s.n,
+                s.rounds,
+                s.round_time,
+                s.position,
+                s.color,
+                s.shape,
+                s.sound,
+            ],
+        )
+        .expect("failed to save settings");
+    }
+
+    // -- scores ------------------------------------------------------------
+
+    pub fn load_scores(&self) -> ScoreHistory {
+        let conn = self.conn.lock().expect("db lock poisoned");
+        let mut stmt = conn.prepare(
+                "SELECT n, total_rounds, round_duration, correct, wrong, f1_score_percent, played_at
+                 FROM scores ORDER BY id DESC LIMIT 50",
+            )
+            .expect("failed to prepare score query");
+
+        let records = stmt
+            .query_map([], |row| {
+                Ok(ScoreRecord {
+                    n: row.get("n")?,
+                    total_rounds: row.get("total_rounds")?,
+                    round_duration: row.get("round_duration")?,
+                    correct: row.get("correct")?,
+                    wrong: row.get("wrong")?,
+                    f1_score_percent: row.get("f1_score_percent")?,
+                    played_at: row.get("played_at")?,
+                })
+            })
+            .expect("failed to load scores")
+            .filter_map(|r| r.ok())
+            .collect();
+
+        ScoreHistory(records)
+    }
+
+    pub fn insert_score(&self, record: &ScoreRecord) {
+        let conn = self.conn.lock().expect("db lock poisoned");
+        conn.execute(
+            "INSERT INTO scores (n, total_rounds, round_duration, correct, wrong, f1_score_percent)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                record.n,
+                record.total_rounds,
+                record.round_duration,
+                record.correct,
+                record.wrong,
+                record.f1_score_percent,
+            ],
+        )
+        .expect("failed to insert score");
+    }
+}
+
+fn db_path() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("nback")
+        .join("nback.db")
+}
+
+pub struct PersistencePlugin;
+
+impl Plugin for PersistencePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            save_settings.run_if(resource_changed::<GameSettings>),
+        );
+    }
+}
+
+/// Persist settings to the database whenever they change.
+fn save_settings(db: Res<Database>, settings: Res<GameSettings>) {
+    db.save_settings(&settings);
+    info!("settings saved");
+}


### PR DESCRIPTION
## Summary

Game settings and score history are now persisted in a SQLite database using `rusqlite` (bundled) and `dirs` for platform-appropriate storage paths.

### Database location

| Platform | Path |
|----------|------|
| macOS | `~/Library/Application Support/nback/nback.db` |
| Linux | `~/.local/share/nback/nback.db` |
| Windows | `C:\Users\<user>\AppData\Roaming\nback\nback.db` |

Falls back to `./nback/nback.db` if no data directory is available.

### Schema

```sql
-- Single-row settings (auto-created with defaults on first run)
CREATE TABLE settings (
    id, n, rounds, round_time, position, color, shape, sound
);

-- One row per completed game session
CREATE TABLE scores (
    id, played_at, n, total_rounds, round_duration,
    correct, wrong, f1_score_percent
);
```

### Behavior

- **Startup**: database is opened/created, settings and last 50 scores loaded
- **Settings change**: `PersistencePlugin` watches `GameSettings` for changes and saves to DB in `PostUpdate` (covers both menu edits and end-of-game difficulty adjustments)
- **Game end**: score is inserted into DB, full history reloaded (so `played_at` timestamps are populated by SQLite)
- **ScoreRecord** gains a `played_at: String` field (ISO-8601, set by `datetime('now')` default)

### Dependencies added

- `rusqlite 0.35` with `bundled` feature (statically links SQLite)
- `dirs 6.0` for platform data directories