### PR TITLE
fix: restore browser wasm build without sqlite persistence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  WASM_BINDGEN_CLI_VERSION: 0.2.117
 
 jobs:
   # Run cargo test
@@ -96,3 +97,46 @@ jobs:
           components: rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
+
+  # Build and package the web target
+  wasm:
+    name: Wasm Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version ${{ env.WASM_BINDGEN_CLI_VERSION }}
+      - name: Build wasm release binary
+        run: cargo build --release --target wasm32-unknown-unknown
+      - name: Smoke-test web packaging
+        run: |
+          out_dir="$(mktemp -d)"
+          wasm-bindgen \
+            --no-typescript \
+            --out-name bevy_game \
+            --out-dir "$out_dir" \
+            --target web \
+            target/wasm32-unknown-unknown/release/nback.wasm
+          cp wasm/index.html wasm/restart-audio-context.js "$out_dir"/
+          test -f "$out_dir/bevy_game.js"
+          test -f "$out_dir/bevy_game_bg.wasm"
+          test -f "$out_dir/index.html"
+          test -f "$out_dir/restart-audio-context.js"
+          (cd "$out_dir" && zip --recurse-paths "$RUNNER_TEMP/nback-wasm.zip" .)
+          test -f "$RUNNER_TEMP/nback-wasm.zip"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 env:
   # update with the name of the main binary
   binary: nback
+  wasm_bindgen_cli_version: 0.2.117
   add_binaries_to_github_release: true
   itch_target: gedl/nback
 
@@ -33,7 +34,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - name: install wasm-bindgen-cli
         run: |
-          cargo install wasm-bindgen-cli
+          cargo install wasm-bindgen-cli --version ${{ env.wasm_bindgen_cli_version }}
 
       - name: Build
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,11 +3021,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4008,6 +4010,7 @@ dependencies = [
  "bevy_embedded_assets",
  "bevy_kira_audio",
  "dirs",
+ "getrandom 0.4.2",
  "image",
  "rand 0.10.0",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,15 @@ bevy_egui = { version = "0.39.1", optional = true, default-features = false, fea
 ] }
 bevy_embedded_assets = "0.15.0"
 bevy_kira_audio = "0.25.0"
-dirs = "6.0"
 image = "0.25.10"
 rand = "0.10.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dirs = "6.0"
 rusqlite = { version = "0.35", features = ["bundled"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.4.2", features = ["wasm_js"] }
 
 [workspace]
 resolver = "2"

--- a/src/game/score.rs
+++ b/src/game/score.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 /// A snapshot of one completed game session for the history table.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ScoreRecord {
     pub n: usize,
     pub total_rounds: usize,
@@ -9,10 +9,10 @@ pub struct ScoreRecord {
     pub correct: usize,
     pub wrong: usize,
     pub f1_score_percent: usize,
-    /// ISO-8601 timestamp (filled by the database on insert).
+    /// Timestamp string filled by the persistence layer on insert.
     pub played_at: String,
 }
 
 /// Accumulated score history across game sessions.
-#[derive(Default, Resource)]
+#[derive(Clone, Default, Resource)]
 pub struct ScoreHistory(pub Vec<ScoreRecord>);

--- a/src/game/settings.rs
+++ b/src/game/settings.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-#[derive(Resource)]
+#[derive(Clone, Resource)]
 pub struct GameSettings {
     pub n: usize,
     pub rounds: usize,

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,6 +1,9 @@
-use std::{path::PathBuf, sync::Mutex};
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
+use std::sync::Mutex;
 
 use bevy::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
 use rusqlite::Connection;
 
 use crate::game::{
@@ -8,6 +11,7 @@ use crate::game::{
     settings::GameSettings,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 /// Wraps a SQLite connection as a Bevy resource.
 ///
 /// `Connection` is not `Sync`, so we wrap it in a `Mutex`.
@@ -16,6 +20,21 @@ pub struct Database {
     conn: Mutex<Connection>,
 }
 
+#[cfg(target_arch = "wasm32")]
+#[derive(Default)]
+struct MemoryDatabase {
+    settings: GameSettings,
+    scores: ScoreHistory,
+}
+
+#[cfg(target_arch = "wasm32")]
+/// In the browser we keep settings and score history in memory only.
+#[derive(Resource, Default)]
+pub struct Database {
+    state: Mutex<MemoryDatabase>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl Database {
     /// Open (or create) the database in the platform data directory.
     ///
@@ -109,7 +128,8 @@ impl Database {
 
     pub fn load_scores(&self) -> ScoreHistory {
         let conn = self.conn.lock().expect("db lock poisoned");
-        let mut stmt = conn.prepare(
+        let mut stmt = conn
+            .prepare(
                 "SELECT n, total_rounds, round_duration, correct, wrong, f1_score_percent, played_at
                  FROM scores ORDER BY id DESC LIMIT 50",
             )
@@ -152,11 +172,54 @@ impl Database {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+impl Database {
+    /// Open the in-memory fallback used by the browser build.
+    pub fn open() -> Self {
+        Database::default()
+    }
+
+    pub fn load_settings(&self) -> GameSettings {
+        self.state
+            .lock()
+            .expect("db lock poisoned")
+            .settings
+            .clone()
+    }
+
+    pub fn save_settings(&self, s: &GameSettings) {
+        self.state.lock().expect("db lock poisoned").settings = s.clone();
+    }
+
+    pub fn load_scores(&self) -> ScoreHistory {
+        self.state.lock().expect("db lock poisoned").scores.clone()
+    }
+
+    pub fn insert_score(&self, record: &ScoreRecord) {
+        let mut state = self.state.lock().expect("db lock poisoned");
+        let mut record = record.clone();
+        record.played_at = session_timestamp();
+        state.scores.0.insert(0, record);
+        state.scores.0.truncate(50);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn db_path() -> PathBuf {
     dirs::data_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join("nback")
         .join("nback.db")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn session_timestamp() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs().to_string())
+        .unwrap_or_default()
 }
 
 pub struct PersistencePlugin;


### PR DESCRIPTION
## Summary
- restore `wasm32-unknown-unknown` builds by removing SQLite and filesystem deps from the browser target
- use an in-memory persistence fallback on wasm while keeping native SQLite persistence unchanged
- add wasm packaging coverage to CI and pin `wasm-bindgen-cli` in release builds

## Changes
- move `dirs` and `rusqlite` behind `cfg(not(target_arch = "wasm32"))`
- enable browser RNG support for wasm via `getrandom`'s `wasm_js` feature
- add a wasm `Database` implementation backed by in-memory settings/score history
- make `GameSettings`, `ScoreRecord`, and `ScoreHistory` clonable for the wasm fallback
- add a CI job that builds release wasm, runs `wasm-bindgen`, and smoke-tests the packaged web bundle
- pin `wasm-bindgen-cli` in release workflow to match the project's `wasm-bindgen` version

## Validation
- `cargo check`
- `cargo check --target wasm32-unknown-unknown`
- `cargo build --target wasm32-unknown-unknown`
- local release-style wasm packaging smoke test
